### PR TITLE
Fix patching page preview causing core plugins to be cleared

### DIFF
--- a/src/types/obsidian.d.ts
+++ b/src/types/obsidian.d.ts
@@ -13,6 +13,16 @@ declare module "obsidian" {
 			enabledPlugins: Set<string>;
 			getPluginFolder(): string;
 		};
+		internalPlugins: {
+			plugins: {
+				[name: string]: {
+					enabled: boolean;
+					enable(): void;
+					disable(): void;
+					instance: any;
+				};
+			};
+		};	
 		commands: any;
 		getTheme: () => string;
 	}
@@ -28,6 +38,8 @@ declare module "obsidian" {
 	}
 
 	interface HoverPopover {
+		targetEl: HTMLElement;	
+
 		hide(): void;
 
 		position({x, y, doc}: {


### PR DESCRIPTION
Resolves #232, #227

Enclosed the patching part inside `app.workspace.onLayoutReady`.
@Quorafind Can you please test it to see if it fixes the problem?